### PR TITLE
Modpack deployment file fix

### DIFF
--- a/Assets/Scripts/FileManager.cs
+++ b/Assets/Scripts/FileManager.cs
@@ -249,7 +249,8 @@ public class FileManager : MonoBehaviour
 
         rawModpack.modpackDirectory = ScanFiles(true);
 
-        rawModpack.modpackDirectory.Files.Remove(deployedFilename);
+        int deployedFile = rawModpack.modpackDirectory.Files.FindIndex(x => x.Contains(deployedFilename));
+        if(deployedFile != -1) rawModpack.modpackDirectory.Files.RemoveAt(deployedFile);
 
         DirectoryCopy(valheimDirectory, workingDirectory, true, DefaultFiles);
 

--- a/Assets/Scripts/PackCreator.cs
+++ b/Assets/Scripts/PackCreator.cs
@@ -85,7 +85,8 @@ public class PackCreator : MonoBehaviour
             changes.text += "<color=green>--> " + folder.Name + "</color>\n";
         }
 
-        directory.Files.Remove(".deployed_modheim_pack");
+        int deployedFile = directory.Files.FindIndex(filename => filename.Contains(".deployed_modheim_pack"));
+        if (deployedFile != -1) directory.Files.RemoveAt(deployedFile);
 
         foreach (string _file in directory.Files)
         {


### PR DESCRIPTION
### Description
Fixed an issue (#5 ) where the modpack deployment file was still displayed on the pack creator screen. 

### What is the current behavior?
If you have a deployed modpack and create a new one, the modpack deployment file is displayed. It did not appear to be included in the file but there's no reason to display it if it's not packaged into the mod.

### What is the new behavior?
Now when creating a modpack from a deployed pack, it will no longer display the deployment file. The code was also added to the pack builder to ensure the file does not get packaged.

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information

<!-- Any other information that is important to this PR such as screenshots, gifs, video of before and after the change are always great -->

N/A